### PR TITLE
fix build error

### DIFF
--- a/chapter2_training/model_db/Dockerfile
+++ b/chapter2_training/model_db/Dockerfile
@@ -6,9 +6,17 @@ ADD requirements.txt /${PROJECT_DIR}/
 RUN apt-get -y update && \
     apt-get -y install \
     apt-utils \
-    gcc && \
+    gcc \
+    libpq-dev \
+    python-dev \
+    git \
+    build-essential \
+    libtool \
+    automake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip install Cython && \
+    pip install git+https://github.com/MagicStack/uvloop && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY src/ /${PROJECT_DIR}/src/


### PR DESCRIPTION
## Environment
 - MacBook Air (M1, 2020)
 - Apple M1
 - Docker version 20.10.6, build 370c289
 - docker-compose version 1.29.1, build c34c88b2

## Report
executed `make build` and below error message was displayed.
```
#9 8.054 Collecting psycopg2-binary>=2.8.6
#9 8.068   Downloading psycopg2-binary-2.8.6.tar.gz (384 kB)
#9 8.193     ERROR: Command errored out with exit status 1:
#9 8.193      command: /usr/local/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-riuri0j5/psycopg2-binary_287a9035c12c4087bb996c9e9c81140b/setup.py'"'"'; __file__='"'"'/tmp/pip-install-riuri0j5/psycopg2-binary_287a9035c12c4087bb996c9e9c81140b/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-1092km0k
#9 8.193          cwd: /tmp/pip-install-riuri0j5/psycopg2-binary_287a9035c12c4087bb996c9e9c81140b/
#9 8.193     Complete output (23 lines):
#9 8.193     running egg_info
#9 8.193     creating /tmp/pip-pip-egg-info-1092km0k/psycopg2_binary.egg-info
#9 8.193     writing /tmp/pip-pip-egg-info-1092km0k/psycopg2_binary.egg-info/PKG-INFO
#9 8.193     writing dependency_links to /tmp/pip-pip-egg-info-1092km0k/psycopg2_binary.egg-info/dependency_links.txt
#9 8.193     writing top-level names to /tmp/pip-pip-egg-info-1092km0k/psycopg2_binary.egg-info/top_level.txt
#9 8.193     writing manifest file '/tmp/pip-pip-egg-info-1092km0k/psycopg2_binary.egg-info/SOURCES.txt'
#9 8.193
#9 8.193     Error: pg_config executable not found.
#9 8.193
#9 8.193     pg_config is required to build psycopg2 from source.  Please add the directory
#9 8.193     containing pg_config to the $PATH or specify the full executable path with the
#9 8.193     option:
#9 8.193
#9 8.193         python setup.py build_ext --pg-config /path/to/pg_config build ...
#9 8.193
#9 8.193     or with the pg_config option in 'setup.cfg'.
#9 8.193
#9 8.193     If you prefer to avoid building psycopg2 from source, please install the PyPI
#9 8.193     'psycopg2-binary' package instead.
#9 8.193
#9 8.193     For further information please check the 'doc/src/install.rst' file (also at
#9 8.193     https://www.psycopg.org/docs/install.html).
#9 8.193
#9 8.193     ----------------------------------------
#9 8.193 WARNING: Discarding https://files.pythonhosted.org/packages/fc/51/0f2c6aec5c59e5640f507b59567f63b9d73a9317898810b4db311da32dfc/psycopg2-binary-2.8.6.tar.gz#sha256=11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0 (from https://pypi.org/simple/psycopg2-binary/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
#9 8.194 ERROR: Could not find a version that satisfies the requirement psycopg2-binary>=2.8.6 (from versions: 2.7.4, 2.7.5, 2.7.6, 2.7.6.1, 2.7.7, 2.8, 2.8.1, 2.8.2, 2.8.3, 2.8.4, 2.8.5, 2.8.6)
#9 8.194 ERROR: No matching distribution found for psycopg2-binary>=2.8.6
------
executor failed running [/bin/sh -c apt-get -y update &&     apt-get -y install     apt-utils     gcc &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     pip install --no-cache-dir -r requirements.txt]: exit code: 1
```
Next, updated Dockerfile.
```
RUN apt-get -y update && \
    apt-get -y install \
    apt-utils \
    gcc \
    libpq-dev \
    python-dev && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/* && \
    pip install --no-cache-dir -r requirements.txt
```
executed `make build` again, then below error message was displayed.
```
#8 14.95   error: [Errno 2] No such file or directory: 'make'
#8 14.95   ----------------------------------------
#8 14.95   ERROR: Failed building wheel for uvloop
```
So, updated Dockerfile.
```
RUN apt-get -y update && \
    apt-get -y install \
    apt-utils \
    gcc \
    libpq-dev \
    python-dev \
    git \
    build-essential \
    libtool \
    automake && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/* && \
    pip install Cython && \
    pip install git+https://github.com/MagicStack/uvloop && \
    pip install --no-cache-dir -r requirements.txt
```
And then, `make build` is succeeded.
